### PR TITLE
persistentcookie must contain a value

### DIFF
--- a/okta/policies.go
+++ b/okta/policies.go
@@ -436,7 +436,7 @@ type SignOn struct {
 	Session                 struct {
 		MaxSessionIdleMinutes     int  `json:"maxSessionIdleMinutes,omitempty"`
 		MaxSessionLifetimeMinutes int  `json:"maxSessionLifetimeMinutes,omitempty"`
-		UsePersistentCookie       bool `json:"usePersistentCookie,omitempty"`
+		UsePersistentCookie       bool `json:"usePersistentCookie"` // field must have a value
 	} `json:"session,omitempty"`
 }
 


### PR DESCRIPTION
the default is false so we remove omitifempty from the json marshal
to ensure that value is migrated to the json