### PR TITLE
Refactor Structs in idps.go to allow omitempty to work properly

### DIFF
--- a/okta/idps.go
+++ b/okta/idps.go
@@ -27,7 +27,7 @@ type Authorize struct {
 	Hints     *Hints `json:"hints,omitempty"`
 }
 
-type Client struct {
+type IdpClient struct {
 	ClientID     string `json:"client_id,omitempty"`
 	ClientSecret string `json:"client_secret,omitempty"`
 }
@@ -43,7 +43,7 @@ type Conditions struct {
 }
 
 type Credentials struct {
-	Client *Client `json:"client,omitempty"`
+	Client *IdpClient `json:"client,omitempty"`
 }
 
 type Deprovisioned struct {
@@ -55,7 +55,7 @@ type Endpoints struct {
 	Token         *Token         `json:"token,omitempty"`
 }
 
-type Groups struct {
+type IdpGroups struct {
 	Action string `json:"action,omitempty"`
 }
 
@@ -64,23 +64,23 @@ type Hints struct {
 }
 
 type IdentityProvider struct {
-	ID          string    `json:"id,omitempty"`
-	Type        string    `json:"type,omitempty"`
-	Status      string    `json:"status,omitempty"`
-	Name        string    `json:"name,omitempty"`
-	Created     time.Time `json:"created,omitempty"`
-	LastUpdated time.Time `json:"lastUpdated,omitempty"`
-	Protocol    *Protocol `json:"protocol,omitempty"`
-	Policy      *Policy   `json:"policy,omitempty"`
-	Links       *Links    `json:"_links,omitempty"`
+	ID          string     `json:"id,omitempty"`
+	Type        string     `json:"type,omitempty"`
+	Status      string     `json:"status,omitempty"`
+	Name        string     `json:"name,omitempty"`
+	Created     time.Time  `json:"created,omitempty"`
+	LastUpdated time.Time  `json:"lastUpdated,omitempty"`
+	Protocol    *Protocol  `json:"protocol,omitempty"`
+	Policy      *IdpPolicy `json:"policy,omitempty"`
+	Links       *IdpLinks  `json:"_links,omitempty"`
 }
 
-type Links struct {
+type IdpLinks struct {
 	Authorize         *Authorize         `json:"authorize,omitempty"`
 	ClientRedirectUri *ClientRedirectUri `json:"clientRedirectUri,omitempty"`
 }
 
-type Policy struct {
+type IdpPolicy struct {
 	Provisioning *Provisioning `json:"provisioning,omitempty"`
 	AccountLink  *AccountLink  `json:"accountLink,omitempty"`
 	Subject      *Subject      `json:"subject,omitempty"`
@@ -97,7 +97,7 @@ type Protocol struct {
 type Provisioning struct {
 	Action        string      `json:"action,omitempty"`
 	ProfileMaster bool        `json:"profileMaster,omitempty"`
-	Groups        *Groups     `json:"groups,omitempty"`
+	Groups        *IdpGroups  `json:"groups,omitempty"`
 	Conditions    *Conditions `json:"conditions,omitempty"`
 }
 

--- a/okta/idps.go
+++ b/okta/idps.go
@@ -11,6 +11,58 @@ func (p *IdentityProvidersService) IdentityProvider() IdentityProvider {
 	return IdentityProvider{}
 }
 
+type AccountLink struct {
+	Filter string `json:"filter,omitempty"`
+	Action string `json:"action,omitempty"`
+}
+
+type Authorization struct {
+	Url     string `json:"url,omitempty"`
+	Binding string `json:"binding,omitempty"`
+}
+
+type Authorize struct {
+	Href      string `json:"href,omitempty"`
+	Templated bool   `json:"templated,omitempty"`
+	Hints     *Hints `json:"hints,omitempty"`
+}
+
+type Client struct {
+	ClientID     string `json:"client_id,omitempty"`
+	ClientSecret string `json:"client_secret,omitempty"`
+}
+
+type ClientRedirectUri struct {
+	Href  string `json:"href,omitempty"`
+	Hints *Hints `json:"hints,omitempty"`
+}
+
+type Conditions struct {
+	Deprovisioned *Deprovisioned `json:"deprovisioned,omitempty"`
+	Suspended     *Suspended     `json:"suspended,omitempty"`
+}
+
+type Credentials struct {
+	Client *Client `json:"client,omitempty"`
+}
+
+type Deprovisioned struct {
+	Action string `json:"action,omitempty"`
+}
+
+type Endpoints struct {
+	Authorization *Authorization `json:"authorization,omitempty"`
+	Token         *Token         `json:"token,omitempty"`
+}
+
+type Groups struct {
+	Action string `json:"action,omitempty"`
+}
+
+type Hints struct {
+	Allow []string `json:"allow,omitempty"`
+}
+
 type IdentityProvider struct {
 	ID          string    `json:"id,omitempty"`
 	Type        string    `json:"type,omitempty"`
@@ -18,70 +70,54 @@ type IdentityProvider struct {
 	Name        string    `json:"name,omitempty"`
 	Created     time.Time `json:"created,omitempty"`
 	LastUpdated time.Time `json:"lastUpdated,omitempty"`
-	Protocol    struct {
-		Type      string `json:"type,omitempty"`
-		Endpoints struct {
-			Authorization struct {
-				Url     string `json:"url,omitempty"`
-				Binding string `json:"binding,omitempty"`
-			} `json:"authorization,omitempty"`
-			Token struct {
-				Url     string `json:"url,omitempty"`
-				Binding string `json:"binding,omitempty"`
-			}
-		} `json:"endpoints,omitempty"`
-		Scopes      []string `json:"scopes,omitempty"`
-		Credentials struct {
-			Client struct {
-				ClientID     string `json:"client_id,omitempty"`
-				ClientSecret string `json:"client_secret,omitempty"`
-			} `json:"client,omitempty"`
-		} `json:"credentials,omitempty"`
-	} `json:"protocol,omitempty"`
-	Policy struct {
-		Provisioning struct {
-			Action        string `json:"action,omitempty"`
-			ProfileMaster bool   `json:"profileMaster,omitempty"`
-			Groups        struct {
-				Action string `json:"action,omitempty"`
-			} `json:"groups,omitempty"`
-			Conditions struct {
-				Deprovisioned struct {
-					Action string `json:"action,omitempty"`
-				} `json:"deprovisioned,omitempty"`
-				Suspended struct {
-					Action string `json:"action,omitempty"`
-				} `json:"suspended,omitempty"`
-			} `json:"conditions,omitempty"`
-		} `json:"provisioning,omitempty"`
-		AccountLink struct {
-			Filter string `json:"filter,omitempty"`
-			Action string `json:"action,omitempty"`
-		} `json:"accountLink,omitempty"`
-		Subject struct {
-			UserNameTemplate struct {
-				Template string `json:"template,omitempty"`
-			} `json:"userNameTemplate,omitempty"`
-			Filter    string `json:"filter,omitempty"`
-			MatchType string `json:"matchType,omitempty"`
-		} `json:"subject,omitempty"`
-		MaxClockSkew int `json:"maxClockSkew,omitempty"`
-	} `json:"policy,omitempty"`
-	Links struct {
-		Authorize struct {
-			Href      string `json:"href,omitempty"`
-			Templated bool   `json:"templated,omitempty"`
-			Hints     struct {
-				Allow []string `json:"allow,omitempty"`
-			} `json:"hints,omitempty"`
-		} `json:"authorize,omitempty"`
-		ClientRedirectUri struct {
-			Href  string `json:"href,omitempty"`
-			Hints struct {
-				Allow []string `json:"allow,omitempty"`
-			} `json:"hints,omitempty"`
-		} `json:"clientRedirectUri,omitempty"`
-	} `json:"_links,omitempty"`
+	Protocol    *Protocol `json:"protocol,omitempty"`
+	Policy      *Policy   `json:"policy,omitempty"`
+	Links       *Links    `json:"_links,omitempty"`
+}
+
+type Links struct {
+	Authorize         *Authorize         `json:"authorize,omitempty"`
+	ClientRedirectUri *ClientRedirectUri `json:"clientRedirectUri,omitempty"`
+}
+
+type Policy struct {
+	Provisioning *Provisioning `json:"provisioning,omitempty"`
+	AccountLink  *AccountLink  `json:"accountLink,omitempty"`
+	Subject      *Subject      `json:"subject,omitempty"`
+	MaxClockSkew int           `json:"maxClockSkew,omitempty"`
+}
+
+type Protocol struct {
+	Type        string       `json:"type,omitempty"`
+	Endpoints   *Endpoints   `json:"endpoints,omitempty"`
+	Scopes      []string     `json:"scopes,omitempty"`
+	Credentials *Credentials `json:"credentials,omitempty"`
+}
+
+type Provisioning struct {
+	Action        string      `json:"action,omitempty"`
+	ProfileMaster bool        `json:"profileMaster,omitempty"`
+	Groups        *Groups     `json:"groups,omitempty"`
+	Conditions    *Conditions `json:"conditions,omitempty"`
+}
+
+type Suspended struct {
+	Action string `json:"action,omitempty"`
+}
+
+type Subject struct {
+	UserNameTemplate *UserNameTemplate `json:"userNameTemplate,omitempty"`
+	Filter           string            `json:"filter,omitempty"`
+	MatchType        string            `json:"matchType,omitempty"`
+}
+
+type Token struct {
+	Url     string `json:"url,omitempty"`
+	Binding string `json:"binding,omitempty"`
+}
+
+type UserNameTemplate struct {
+	Template string `json:"template,omitempty"`
 }
 
 // GetIdentityProvider: Get an IdP
@@ -107,6 +143,7 @@ func (p *IdentityProvidersService) GetIdentityProvider(id string) (*IdentityProv
 func (p *IdentityProvidersService) CreateIdentityProvider(idp interface{}) (*IdentityProvider, *Response, error) {
 	u := fmt.Sprintf("idps")
 	req, err := p.client.NewRequest("POST", u, idp)
+
 	if err != nil {
 		return nil, nil, err
 	}

--- a/okta/idps_test.go
+++ b/okta/idps_test.go
@@ -9,45 +9,71 @@ import (
 	"time"
 )
 
+var testAccountLink *AccountLink
+var testAuthorization *Authorization
+var testAuthorize *Authorize
+var testClient *Client
+var testClientRedirectUri *ClientRedirectUri
+var testCredentials *Credentials
+var testDeprovisioned *Deprovisioned
+var testHints *Hints
 var testIdentityProvider *IdentityProvider
+var testLinks *links
+var testPolicy *Policy
+var testProtocol *Protocol
+var testProvisioning *Provisioning
+var testSuspended *Suspended
+var testSubject *Subject
+var testToken *Token
+var testUserNameTemplate *UserNameTemplate
 
 func setupTestIdentityProvider() {
 	hmm, _ := time.Parse("2006-01-02T15:04:05.000Z", "2018-02-16T19:59:05.000Z")
 
-	testIdentityProvider = &IdentityProvider{
-		Type:        "GOOGLE",
-		Status:      "ACTIVE",
-		Name:        "Google",
-		Created:     hmm,
-		LastUpdated: hmm,
+  testAccountLink = &AccountLink {
+  	Action: "NONE",
+  	Filter: "NONE",
+  }
+
+  testPolicy = &Policy {
+    MaxClockSkew: 0,
+  }
+
+  testProvisioning = &Provisioning {
+  	Action: "NONE",
+  	ProfileMaster: false,
+  }
+
+  testSubject = &Subject {
+    Filter:    "NONE",
+    MatchType: "USERNAME",
+  }
+
+	testProtocol = &Protocol {
+		Type: "OIDC",
 	}
-	testIdentityProvider.Protocol.Type = "OIDC"
-	testIdentityProvider.Protocol.Endpoints.Authorization.Url = "https://accounts.google.com/o/oauth2/auth"
-	testIdentityProvider.Protocol.Endpoints.Authorization.Binding = "HTTP-REDIRECT"
-	testIdentityProvider.Protocol.Endpoints.Token.Url = "https://www.googleapis.com/oauth2/v3/token"
-	testIdentityProvider.Protocol.Endpoints.Token.Binding = "HTTP-POST"
-	testIdentityProvider.Protocol.Scopes = []string{"profile email openid"}
-	testIdentityProvider.Protocol.Credentials.Client.ClientID = "your-client-id"
-	testIdentityProvider.Protocol.Credentials.Client.ClientSecret = "your-client-secret"
-	testIdentityProvider.Policy.Provisioning.Action = "AUTO"
-	testIdentityProvider.Policy.Provisioning.ProfileMaster = true
-	testIdentityProvider.Policy.Provisioning.Groups.Action = "NONE"
-	testIdentityProvider.Policy.Provisioning.Conditions.Deprovisioned.Action = "NONE"
-	testIdentityProvider.Policy.Provisioning.Conditions.Suspended.Action = "NONE"
-	// testIdentityProvider.Policy.AccountLink.Filter = null
-	testIdentityProvider.Policy.AccountLink.Action = "AUTO"
-	testIdentityProvider.Policy.Subject.UserNameTemplate.Template = "idpuser.userPrincipalName"
-	// testIdentityProvider.Policy.Subject.Filter = null
-	testIdentityProvider.Policy.Subject.MatchType = "USERNAME"
-	testIdentityProvider.Policy.MaxClockSkew = 0
-	testIdentityProvider.Links.Authorize.Href = "https://{yourOktaDomain}/oauth2/v1/authorize?idp=0oa62bfdiumsUndnZ0h7&client_id={clientId}&response_type={responseType}&response_mode={responseMode}&scope={scopes}&redirect_uri={redirectUri}&state={state}"
-	testIdentityProvider.Links.Authorize.Templated = true
-	testIdentityProvider.Links.Authorize.Hints.Allow = []string{"GET"}
-	testIdentityProvider.Links.ClientRedirectUri.Href = "https://{yourOktaDomain}/oauth2/v1/authorize/callback"
-	testIdentityProvider.Links.ClientRedirectUri.Hints.Allow = []string{"POST"}
+
+	testProtocol.Scopes = []string{"profile email openid"}
+	testProtocol.Credentials.Client.ClientID = "your-client-id"
+	testProtocol.Credentials.Client.ClientSecret = "your-client-secret"
+	testProvisioning.Groups.Action = "NONE"
+	testProvisioning.Conditions.Deprovisioned.Action = "NONE"
+	testProvisioning.Conditions.Suspended.Action = "NONE"
+	testSubject.UserNameTemplate.Template = "idpuser.userPrincipalName"
+
+	testIdentityProvider = &IdentityProvider {
+		Type:        "GOOGLE",
+		Name:        "Google",
+	}
+
+	testIdentityProvider.Protocol = testProtocol
+	testIdentityProvider.Policy = testPolicy
+	testIdentityProvider.Policy.Provisioning = testProvisioning
+	testIdentityProvider.Policy.AccountLink = testAccountLink
+  testIdentityProvider.Policy.Subject = testSubject
 }
 
-func TestGetIdentityProvider(t *testing.T) {
+func TestGetIdentityProvider(t &testing.T) {
 	setup()
 	defer teardown()
 	setupTestIdentityProvider()
@@ -59,7 +85,7 @@ func TestGetIdentityProvider(t *testing.T) {
 	}
 	IdentityProviderTestJSONString := string(temp)
 
-	mux.HandleFunc("/idps/0oa62bfdiumsUndnZ0h7", func(w http.ResponseWriter, r *http.Request) {
+	mux.HandleFunc("/idps/0oa62bfdiumsUndnZ0h7", func(w http.ResponseWriter, r &http.Request) {
 		testMethod(t, r, "GET")
 		testAuthHeader(t, r)
 		fmt.Fprint(w, IdentityProviderTestJSONString)
@@ -74,7 +100,7 @@ func TestGetIdentityProvider(t *testing.T) {
 	}
 }
 
-func TestIdentityProviderCreate(t *testing.T) {
+func TestIdentityProviderCreate(t &testing.T) {
 
 	setup()
 	defer teardown()
@@ -88,7 +114,7 @@ func TestIdentityProviderCreate(t *testing.T) {
 
 	IdentityProviderTestJSONString := string(temp)
 
-	mux.HandleFunc("/idps", func(w http.ResponseWriter, r *http.Request) {
+	mux.HandleFunc("/idps", func(w http.ResponseWriter, r &http.Request) {
 		testMethod(t, r, "POST")
 		testAuthHeader(t, r)
 		fmt.Fprint(w, IdentityProviderTestJSONString)
@@ -103,7 +129,7 @@ func TestIdentityProviderCreate(t *testing.T) {
 	}
 }
 
-func TestIdentityProviderUpdate(t *testing.T) {
+func TestIdentityProviderUpdate(t &testing.T) {
 
 	setup()
 	defer teardown()
@@ -117,7 +143,7 @@ func TestIdentityProviderUpdate(t *testing.T) {
 	}
 	updateTestJSONString := string(temp)
 
-	mux.HandleFunc("/idps/0oa62bfdiumsUndnZ0h7", func(w http.ResponseWriter, r *http.Request) {
+	mux.HandleFunc("/idps/0oa62bfdiumsUndnZ0h7", func(w http.ResponseWriter, r &http.Request) {
 		testMethod(t, r, "PUT")
 		testAuthHeader(t, r)
 		fmt.Fprint(w, updateTestJSONString)
@@ -132,7 +158,7 @@ func TestIdentityProviderUpdate(t *testing.T) {
 	}
 }
 
-func TestIdentityProviderDelete(t *testing.T) {
+func TestIdentityProviderDelete(t &testing.T) {
 
 	setup()
 	defer teardown()
@@ -140,7 +166,7 @@ func TestIdentityProviderDelete(t *testing.T) {
 
 	testIdentityProvider.ID = "0oa62bfdiumsUndnZ0h7"
 
-	mux.HandleFunc("/idps/0oa62bfdiumsUndnZ0h7", func(w http.ResponseWriter, r *http.Request) {
+	mux.HandleFunc("/idps/0oa62bfdiumsUndnZ0h7", func(w http.ResponseWriter, r &http.Request) {
 		testMethod(t, r, "DELETE")
 		testAuthHeader(t, r)
 		fmt.Fprint(w, "")

--- a/okta/idps_test.go
+++ b/okta/idps_test.go
@@ -30,26 +30,26 @@ var testUserNameTemplate *UserNameTemplate
 func setupTestIdentityProvider() {
 	hmm, _ := time.Parse("2006-01-02T15:04:05.000Z", "2018-02-16T19:59:05.000Z")
 
-  testAccountLink = &AccountLink {
-  	Action: "NONE",
-  	Filter: "NONE",
-  }
+	testAccountLink = &AccountLink{
+		Action: "NONE",
+		Filter: "NONE",
+	}
 
-  testPolicy = &Policy {
-    MaxClockSkew: 0,
-  }
+	testPolicy = &Policy{
+		MaxClockSkew: 0,
+	}
 
-  testProvisioning = &Provisioning {
-  	Action: "NONE",
-  	ProfileMaster: false,
-  }
+	testProvisioning = &Provisioning{
+		Action:        "NONE",
+		ProfileMaster: false,
+	}
 
-  testSubject = &Subject {
-    Filter:    "NONE",
-    MatchType: "USERNAME",
-  }
+	testSubject = &Subject{
+		Filter:    "NONE",
+		MatchType: "USERNAME",
+	}
 
-	testProtocol = &Protocol {
+	testProtocol = &Protocol{
 		Type: "OIDC",
 	}
 
@@ -61,19 +61,19 @@ func setupTestIdentityProvider() {
 	testProvisioning.Conditions.Suspended.Action = "NONE"
 	testSubject.UserNameTemplate.Template = "idpuser.userPrincipalName"
 
-	testIdentityProvider = &IdentityProvider {
-		Type:        "GOOGLE",
-		Name:        "Google",
+	testIdentityProvider = &IdentityProvider{
+		Type: "GOOGLE",
+		Name: "Google",
 	}
 
 	testIdentityProvider.Protocol = testProtocol
 	testIdentityProvider.Policy = testPolicy
 	testIdentityProvider.Policy.Provisioning = testProvisioning
 	testIdentityProvider.Policy.AccountLink = testAccountLink
-  testIdentityProvider.Policy.Subject = testSubject
+	testIdentityProvider.Policy.Subject = testSubject
 }
 
-func TestGetIdentityProvider(t &testing.T) {
+func TestGetIdentityProvider(t *testing.T) {
 	setup()
 	defer teardown()
 	setupTestIdentityProvider()
@@ -85,7 +85,7 @@ func TestGetIdentityProvider(t &testing.T) {
 	}
 	IdentityProviderTestJSONString := string(temp)
 
-	mux.HandleFunc("/idps/0oa62bfdiumsUndnZ0h7", func(w http.ResponseWriter, r &http.Request) {
+	mux.HandleFunc("/idps/0oa62bfdiumsUndnZ0h7", func(w http.ResponseWriter, r *http.Request) {
 		testMethod(t, r, "GET")
 		testAuthHeader(t, r)
 		fmt.Fprint(w, IdentityProviderTestJSONString)
@@ -100,7 +100,7 @@ func TestGetIdentityProvider(t &testing.T) {
 	}
 }
 
-func TestIdentityProviderCreate(t &testing.T) {
+func TestIdentityProviderCreate(t *testing.T) {
 
 	setup()
 	defer teardown()
@@ -114,7 +114,7 @@ func TestIdentityProviderCreate(t &testing.T) {
 
 	IdentityProviderTestJSONString := string(temp)
 
-	mux.HandleFunc("/idps", func(w http.ResponseWriter, r &http.Request) {
+	mux.HandleFunc("/idps", func(w http.ResponseWriter, r *http.Request) {
 		testMethod(t, r, "POST")
 		testAuthHeader(t, r)
 		fmt.Fprint(w, IdentityProviderTestJSONString)
@@ -129,7 +129,7 @@ func TestIdentityProviderCreate(t &testing.T) {
 	}
 }
 
-func TestIdentityProviderUpdate(t &testing.T) {
+func TestIdentityProviderUpdate(t *testing.T) {
 
 	setup()
 	defer teardown()
@@ -143,7 +143,7 @@ func TestIdentityProviderUpdate(t &testing.T) {
 	}
 	updateTestJSONString := string(temp)
 
-	mux.HandleFunc("/idps/0oa62bfdiumsUndnZ0h7", func(w http.ResponseWriter, r &http.Request) {
+	mux.HandleFunc("/idps/0oa62bfdiumsUndnZ0h7", func(w http.ResponseWriter, r *http.Request) {
 		testMethod(t, r, "PUT")
 		testAuthHeader(t, r)
 		fmt.Fprint(w, updateTestJSONString)
@@ -158,7 +158,7 @@ func TestIdentityProviderUpdate(t &testing.T) {
 	}
 }
 
-func TestIdentityProviderDelete(t &testing.T) {
+func TestIdentityProviderDelete(t *testing.T) {
 
 	setup()
 	defer teardown()
@@ -166,7 +166,7 @@ func TestIdentityProviderDelete(t &testing.T) {
 
 	testIdentityProvider.ID = "0oa62bfdiumsUndnZ0h7"
 
-	mux.HandleFunc("/idps/0oa62bfdiumsUndnZ0h7", func(w http.ResponseWriter, r &http.Request) {
+	mux.HandleFunc("/idps/0oa62bfdiumsUndnZ0h7", func(w http.ResponseWriter, r *http.Request) {
 		testMethod(t, r, "DELETE")
 		testAuthHeader(t, r)
 		fmt.Fprint(w, "")

--- a/okta/idps_test.go
+++ b/okta/idps_test.go
@@ -6,51 +6,63 @@ import (
 	"net/http"
 	"reflect"
 	"testing"
-	"time"
 )
 
 var testAccountLink *AccountLink
-var testAuthorization *Authorization
-var testAuthorize *Authorize
-var testClient *Client
-var testClientRedirectUri *ClientRedirectUri
+var testClient *IdpClient
+var testConditions *Conditions
 var testCredentials *Credentials
 var testDeprovisioned *Deprovisioned
-var testHints *Hints
+var testGroups *IdpGroups
 var testIdentityProvider *IdentityProvider
-var testLinks *links
-var testPolicy *Policy
+var testIdpPolicy *IdpPolicy
 var testProtocol *Protocol
 var testProvisioning *Provisioning
-var testSuspended *Suspended
 var testSubject *Subject
-var testToken *Token
+var testSuspended *Suspended
 var testUserNameTemplate *UserNameTemplate
 
 func setupTestIdentityProvider() {
-	hmm, _ := time.Parse("2006-01-02T15:04:05.000Z", "2018-02-16T19:59:05.000Z")
+	testClient = &IdpClient{}
+	testDeprovisioned = &Deprovisioned{}
+	testGroups = &IdpGroups{}
+	testSuspended = &Suspended{}
+	testUserNameTemplate = &UserNameTemplate{}
 
 	testAccountLink = &AccountLink{
 		Action: "NONE",
 		Filter: "NONE",
 	}
 
-	testPolicy = &Policy{
+	testConditions = &Conditions{
+		Deprovisioned: testDeprovisioned,
+		Suspended:     testSuspended,
+	}
+
+	testCredentials = &Credentials{
+		Client: testClient,
+	}
+
+	testIdpPolicy = &IdpPolicy{
 		MaxClockSkew: 0,
+	}
+
+	testProtocol = &Protocol{
+		Credentials: testCredentials,
+		Type:        "OIDC",
 	}
 
 	testProvisioning = &Provisioning{
 		Action:        "NONE",
+		Conditions:    testConditions,
+		Groups:        testGroups,
 		ProfileMaster: false,
 	}
 
 	testSubject = &Subject{
-		Filter:    "NONE",
-		MatchType: "USERNAME",
-	}
-
-	testProtocol = &Protocol{
-		Type: "OIDC",
+		Filter:           "NONE",
+		MatchType:        "USERNAME",
+		UserNameTemplate: testUserNameTemplate,
 	}
 
 	testProtocol.Scopes = []string{"profile email openid"}
@@ -67,7 +79,7 @@ func setupTestIdentityProvider() {
 	}
 
 	testIdentityProvider.Protocol = testProtocol
-	testIdentityProvider.Policy = testPolicy
+	testIdentityProvider.Policy = testIdpPolicy
 	testIdentityProvider.Policy.Provisioning = testProvisioning
 	testIdentityProvider.Policy.AccountLink = testAccountLink
 	testIdentityProvider.Policy.Subject = testSubject


### PR DESCRIPTION
![](https://thumbs.gfycat.com/SlightCandidAxolotl-size_restricted.gif)

`omitempty` was not omitting members that were nested as anonymous structs within other structs.  Needed to break them apart into named structs with references to them via pointers so `omitempty` wouldn't send blank fields to okta via the client request.