### PR TITLE
add group assignment member to IdpGroups struct

### DIFF
--- a/okta/idps.go
+++ b/okta/idps.go
@@ -56,7 +56,8 @@ type Endpoints struct {
 }
 
 type IdpGroups struct {
-	Action string `json:"action,omitempty"`
+	Action      string   `json:"action,omitempty"`
+	Assignments []string `json:"assignments,omitempty"`
 }
 
 type Hints struct {


### PR DESCRIPTION
add the ability to assign groups to an IDP so when users login via the IDP they are automatically assigned to a group in Okta.