### PR TITLE
adding Trusted Origins to the sdk

### DIFF
--- a/okta/idps.go
+++ b/okta/idps.go
@@ -123,7 +123,7 @@ type UserNameTemplate struct {
 	Template string `json:"template,omitempty"`
 }
 
-// GetIdentityProvider: Get an IdP
+// GetIdentityProvider: Get an Identity Provider
 // Requires IdentityProvider ID from IdentityProvider object
 func (p *IdentityProvidersService) GetIdentityProvider(id string) (*IdentityProvider, *Response, error) {
 	u := fmt.Sprintf("idps/%v", id)
@@ -141,8 +141,8 @@ func (p *IdentityProvidersService) GetIdentityProvider(id string) (*IdentityProv
 	return idp, resp, err
 }
 
-// CreateIdentityprovider: Create a identityprovider
-// You must pass in the Identityprovider object created from the desired input identityprovider
+// CreateIdentityProvider: Create an Identity Provider
+// You must pass in the IdentityProvider object created from the desired input IdentityProvider
 func (p *IdentityProvidersService) CreateIdentityProvider(idp interface{}) (*IdentityProvider, *Response, error) {
 	u := fmt.Sprintf("idps")
 	req, err := p.client.NewRequest("POST", u, idp)
@@ -161,8 +161,8 @@ func (p *IdentityProvidersService) CreateIdentityProvider(idp interface{}) (*Ide
 	return newIdp, resp, err
 }
 
-// UpdateIdentityProvider: Update a policy
-// Requires IdentityProvider ID from IdentityProvider object & IdentityProvider object from the desired input policy
+// UpdateIdentityProvider: Update an Identity Provider
+// Requires IdentityProvider ID from IdentityProvider object & IdentityProvider object from the desired input IdentityProvider
 func (p *IdentityProvidersService) UpdateIdentityProvider(id string, idp interface{}) (*IdentityProvider, *Response, error) {
 	u := fmt.Sprintf("idps/%v", id)
 	req, err := p.client.NewRequest("PUT", u, idp)
@@ -179,8 +179,8 @@ func (p *IdentityProvidersService) UpdateIdentityProvider(id string, idp interfa
 	return updateIdentityProvider, resp, err
 }
 
-// DeleteIdentityprovider: Delete a identityprovider
-// Requires Identityprovider ID from Identityprovider object
+// DeleteIdentityProvider: Delete an Identity Provider
+// Requires IdentityProvider ID from IdentityProvider object
 func (p *IdentityProvidersService) DeleteIdentityProvider(id string) (*Response, error) {
 	u := fmt.Sprintf("idps/%v", id)
 	req, err := p.client.NewRequest("DELETE", u, nil)

--- a/okta/sdk.go
+++ b/okta/sdk.go
@@ -97,6 +97,9 @@ type Client struct {
 
 	// Service for Working with Identity Providers
 	IdentityProviders *IdentityProvidersService
+
+	// Service for Working with Trusted Origins
+	TrustedOrigins *TrustedOriginsService
 }
 
 type service struct {
@@ -151,6 +154,7 @@ func NewClientWithBaseURL(httpClient *http.Client, baseURL *url.URL, apiToken st
 	c.Policies = (*PoliciesService)(&c.common)
 	c.Schemas = (*SchemasService)(&c.common)
 	c.IdentityProviders = (*IdentityProvidersService)(&c.common)
+	c.TrustedOrigins = (*TrustedOriginsService)(&c.common)
 	return c
 }
 

--- a/okta/trusted_origins.go
+++ b/okta/trusted_origins.go
@@ -1,0 +1,62 @@
+package okta
+
+import (
+	"fmt"
+	"time"
+)
+
+type TrustedOriginsService service
+
+func (p *TrustedOriginsService) TrustedOrigin() TrustedOrigin {
+	return TrustedOrigin{}
+}
+
+type TrustedOrigin struct {
+	ID            string              `json:"id,omitempty"`
+	Status        string              `json:"status,omitempty"`
+	Name          string              `json:"name,omitempty"`
+	Origin        string              `json:"origin,omitempty"`
+	Scopes        []map[string]string `json:"scopes,omitempty"`
+	Created       *time.Time          `json:"created,omitempty"`
+	CreatedBy     string              `json:"createdBy,omitempty"`
+	LastUpdated   *time.Time          `json:"lastUpdated,omitempty"`
+	LastUpdatedBy string              `json:"lastUpdated,omitempty"`
+	Links         *TrustedOriginLinks `json:"_links,omitempty"`
+}
+
+type TrustedOriginDeactive struct {
+	Href  string              `json:"href,omitempty"`
+	Hints *TrustedOriginHints `json:"hints,omitempty`
+}
+
+type TrustedOriginHints struct {
+	Allow []string `json:"allow,omitempty"`
+}
+
+type TrustedOriginLinks struct {
+	Self       *TrustedOriginSelf     `json:"self,omitempty"`
+	Deactivate *TrustedOriginDeactive `json:"deactive,omitempty"`
+}
+
+type TrustedOriginSelf struct {
+	Href  string              `json:"href,omitempty"`
+	Hints *TrustedOriginHints `json:"hints,omitempty`
+}
+
+// GetTrustedOrigin: Get a Trusted Origin entry
+// Requires TrustedOrigins ID from TrustedOrigins object
+func (p *TrustedOriginsService) GetTrustedOrigin(id string) (*TrustedOrigin, *Response, error) {
+	u := fmt.Sprintf("trustedOrigins/%v", id)
+	req, err := p.client.NewRequest("GET", u, nil)
+	if err != nil {
+		return nil, nil, err
+	}
+
+	trustedOrigin := new(TrustedOrigin)
+	resp, err := p.client.Do(req, trustedOrigin)
+	if err != nil {
+		return nil, resp, err
+	}
+
+	return trustedOrigin, resp, err
+}

--- a/okta/trusted_origins.go
+++ b/okta/trusted_origins.go
@@ -80,3 +80,21 @@ func (p *TrustedOriginsService) CreateTrustedOrigin(trustedOrigin interface{}) (
 
 	return newTrustedOrigin, resp, err
 }
+
+// UpdateTrustedOrigin: Update a Trusted Origin
+// Requires TrustedOrigin ID from TrustedOrigin object & TrustedOrigin object from the desired input policy
+func (p *TrustedOriginsService) UpdateTrustedOrigin(id string, trustedOrigin interface{}) (*TrustedOrigin, *Response, error) {
+	u := fmt.Sprintf("trustedOrigins/%v", id)
+	req, err := p.client.NewRequest("PUT", u, trustedOrigin)
+	if err != nil {
+		return nil, nil, err
+	}
+
+	updateTrustedOrigin := new(TrustedOrigin)
+	resp, err := p.client.Do(req, updateTrustedOrigin)
+	if err != nil {
+		return nil, resp, err
+	}
+
+	return updateTrustedOrigin, resp, err
+}

--- a/okta/trusted_origins.go
+++ b/okta/trusted_origins.go
@@ -98,3 +98,19 @@ func (p *TrustedOriginsService) UpdateTrustedOrigin(id string, trustedOrigin int
 
 	return updateTrustedOrigin, resp, err
 }
+
+// DeleteTrustedOrigin: Delete a Trusted Origin
+// Requires TrustedOrigin ID from TrustedOrigin object
+func (p *TrustedOriginsService) DeleteTrustedOrigin(id string) (*Response, error) {
+	u := fmt.Sprintf("trustedOrigins/%v", id)
+	req, err := p.client.NewRequest("DELETE", u, nil)
+	if err != nil {
+		return nil, err
+	}
+	resp, err := p.client.Do(req, nil)
+	if err != nil {
+		return resp, err
+	}
+
+	return resp, err
+}

--- a/okta/trusted_origins.go
+++ b/okta/trusted_origins.go
@@ -138,3 +138,18 @@ func (p *TrustedOriginsService) ActivateTrustedOrigin(id string, activate bool) 
 
 	return resp, err
 }
+
+// ListTrustedOrigins: Lists all Trusted Origins from an Okta Account
+func (p *TrustedOriginsService) ListTrustedOrigins() (*Response, error) {
+	u := fmt.Sprintf("trustedOrigins")
+	req, err := p.client.NewRequest("GET", u, nil)
+	if err != nil {
+		return nil, err
+	}
+	resp, err := p.client.Do(req, nil)
+	if err != nil {
+		return resp, err
+	}
+
+	return resp, err
+}

--- a/okta/trusted_origins.go
+++ b/okta/trusted_origins.go
@@ -114,3 +114,27 @@ func (p *TrustedOriginsService) DeleteTrustedOrigin(id string) (*Response, error
 
 	return resp, err
 }
+
+// ActivateTrustedOrigin: Activate/Deactivate a Trusted Origin
+// Requires TrustedOrigin ID from TrustedOrigin object and a boolean to activate or deactivate
+func (p *TrustedOriginsService) ActivateTrustedOrigin(id string, activate bool) (*Response, error) {
+	var a string
+
+	if activate {
+		a = "activate"
+	} else {
+		a = "deactivate"
+	}
+
+	u := fmt.Sprintf("trustedOrigins/%v/lifecycle/%v", id, a)
+	req, err := p.client.NewRequest("POST", u, nil)
+	if err != nil {
+		return nil, err
+	}
+	resp, err := p.client.Do(req, nil)
+	if err != nil {
+		return resp, err
+	}
+
+	return resp, err
+}

--- a/okta/trusted_origins.go
+++ b/okta/trusted_origins.go
@@ -60,3 +60,23 @@ func (p *TrustedOriginsService) GetTrustedOrigin(id string) (*TrustedOrigin, *Re
 
 	return trustedOrigin, resp, err
 }
+
+// CreateTrustedOrigin: Create a Trusted Origin
+// You must pass in the Trusted Origin object created from the desired input trustedOrigin
+func (p *TrustedOriginsService) CreateTrustedOrigin(trustedOrigin interface{}) (*TrustedOrigin, *Response, error) {
+	u := fmt.Sprintf("trustedOrigins")
+	req, err := p.client.NewRequest("POST", u, trustedOrigin)
+
+	if err != nil {
+		return nil, nil, err
+	}
+
+	newTrustedOrigin := new(TrustedOrigin)
+
+	resp, err := p.client.Do(req, newTrustedOrigin)
+	if err != nil {
+		return nil, resp, err
+	}
+
+	return newTrustedOrigin, resp, err
+}

--- a/okta/trusted_origins_test.go
+++ b/okta/trusted_origins_test.go
@@ -147,3 +147,19 @@ func TestTrustedOriginActivate(t *testing.T) {
 		t.Errorf("TrustedOrigins.ActivateTrustedOrigin returned error: %v", err)
 	}
 }
+
+func TestTrustedOriginsList(t *testing.T) {
+	setup()
+	defer teardown()
+
+	mux.HandleFunc("/trustedOrigins", func(w http.ResponseWriter, r *http.Request) {
+		testMethod(t, r, "GET")
+		testAuthHeader(t, r)
+		fmt.Fprint(w, "")
+	})
+
+	_, err := client.TrustedOrigins.ListTrustedOrigins()
+	if err != nil {
+		t.Errorf("TrustedOrigins.ListTrustedOrigins returned error: %v", err)
+	}
+}

--- a/okta/trusted_origins_test.go
+++ b/okta/trusted_origins_test.go
@@ -53,3 +53,32 @@ func TestGetTrustedOrigin(t *testing.T) {
 		t.Errorf("client.TrustedOrigins.GetTrustedOrigin returned \n\t%+v, want \n\t%+v\n", outputTrustedOrigin, testTrustedOrigin)
 	}
 }
+
+func TestTrustedOriginCreate(t *testing.T) {
+
+	setup()
+	defer teardown()
+	setupTestTrustedOrigin()
+
+	temp, err := json.Marshal(testTrustedOrigin)
+
+	if err != nil {
+		t.Errorf("TrustedOrigins.CreateTrustedOrigin json Marshall returned error: %v", err)
+	}
+
+	TrustedOriginTestJSONString := string(temp)
+
+	mux.HandleFunc("/trustedOrigins", func(w http.ResponseWriter, r *http.Request) {
+		testMethod(t, r, "POST")
+		testAuthHeader(t, r)
+		fmt.Fprint(w, TrustedOriginTestJSONString)
+	})
+
+	outputTrustedOrigin, _, err := client.TrustedOrigins.CreateTrustedOrigin(testTrustedOrigin)
+	if err != nil {
+		t.Errorf("client.TrustedOrigins.CreateTrustedOrigin returned error: %v", err)
+	}
+	if !reflect.DeepEqual(outputTrustedOrigin, testTrustedOrigin) {
+		t.Errorf("client.TrustedOrigins.CreateTrustedOrigin returned \n\t%+v, want \n\t%+v\n", outputTrustedOrigin, testTrustedOrigin)
+	}
+}

--- a/okta/trusted_origins_test.go
+++ b/okta/trusted_origins_test.go
@@ -55,7 +55,6 @@ func TestGetTrustedOrigin(t *testing.T) {
 }
 
 func TestTrustedOriginCreate(t *testing.T) {
-
 	setup()
 	defer teardown()
 	setupTestTrustedOrigin()
@@ -80,5 +79,33 @@ func TestTrustedOriginCreate(t *testing.T) {
 	}
 	if !reflect.DeepEqual(outputTrustedOrigin, testTrustedOrigin) {
 		t.Errorf("client.TrustedOrigins.CreateTrustedOrigin returned \n\t%+v, want \n\t%+v\n", outputTrustedOrigin, testTrustedOrigin)
+	}
+}
+
+func TestTrustedOriginUpdate(t *testing.T) {
+	setup()
+	defer teardown()
+	setupTestTrustedOrigin()
+	testTrustedOrigin.ID = "ow1y4s2cpS59f1xs2p7"
+
+	testTrustedOrigin.Name = "Testing Update"
+	temp, err := json.Marshal(testTrustedOrigin)
+	if err != nil {
+		t.Errorf("TrustedOrigins.UpdateTrustedOrigin json Marshall returned error: %v", err)
+	}
+	updateTestJSONString := string(temp)
+
+	mux.HandleFunc("/trustedOrigins/ow1y4s2cpS59f1xs2p7", func(w http.ResponseWriter, r *http.Request) {
+		testMethod(t, r, "PUT")
+		testAuthHeader(t, r)
+		fmt.Fprint(w, updateTestJSONString)
+	})
+
+	outputTrustedOrigin, _, err := client.TrustedOrigins.UpdateTrustedOrigin("ow1y4s2cpS59f1xs2p7", testTrustedOrigin)
+	if err != nil {
+		t.Errorf("client.TrustedOrigins.UpdateTrustedOrigin returned error: %v", err)
+	}
+	if !reflect.DeepEqual(outputTrustedOrigin.Name, testTrustedOrigin.Name) {
+		t.Errorf("client.TrustedOrigins.UpdateTrustedOrigin returned \n\t%+v, want \n\t%+v\n", outputTrustedOrigin.Name, testTrustedOrigin.Name)
 	}
 }

--- a/okta/trusted_origins_test.go
+++ b/okta/trusted_origins_test.go
@@ -1,0 +1,55 @@
+package okta
+
+import (
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"reflect"
+	"testing"
+)
+
+var testTrustedOrigin *TrustedOrigin
+
+func setupTestTrustedOrigin() {
+	scopeTypes := []string{"CORS", "Redirect"}
+
+	var scopes []map[string]string
+
+	for _, scopeType := range scopeTypes {
+		scopes = append(scopes, map[string]string{"Type": scopeType})
+	}
+
+	testTrustedOrigin = &TrustedOrigin{
+		Origin: "http://testing.com",
+		Name:   "Testing",
+		Scopes: scopes,
+	}
+}
+
+func TestGetTrustedOrigin(t *testing.T) {
+	setup()
+	defer teardown()
+	setupTestTrustedOrigin()
+	testTrustedOrigin.ID = "ow1y4s2cpS59f1xs2p7"
+
+	temp, err := json.Marshal(testTrustedOrigin)
+	if err != nil {
+		t.Errorf("TrustedOrigins.GetTrustedOrigin json Marshall returned error: %v", err)
+	}
+
+	trustedOriginTestJSONString := string(temp)
+
+	mux.HandleFunc("/trustedOrigins/ow1y4s2cpS59f1xs2p7", func(w http.ResponseWriter, r *http.Request) {
+		testMethod(t, r, "GET")
+		testAuthHeader(t, r)
+		fmt.Fprint(w, trustedOriginTestJSONString)
+	})
+
+	outputTrustedOrigin, _, err := client.TrustedOrigins.GetTrustedOrigin("ow1y4s2cpS59f1xs2p7")
+	if err != nil {
+		t.Errorf("TrustedOrigins.GetTrustedOrigin returned error: %v", err)
+	}
+	if !reflect.DeepEqual(outputTrustedOrigin, testTrustedOrigin) {
+		t.Errorf("client.TrustedOrigins.GetTrustedOrigin returned \n\t%+v, want \n\t%+v\n", outputTrustedOrigin, testTrustedOrigin)
+	}
+}

--- a/okta/trusted_origins_test.go
+++ b/okta/trusted_origins_test.go
@@ -111,7 +111,6 @@ func TestTrustedOriginUpdate(t *testing.T) {
 }
 
 func TestTrustedOriginDelete(t *testing.T) {
-
 	setup()
 	defer teardown()
 	setupTestTrustedOrigin()
@@ -127,5 +126,24 @@ func TestTrustedOriginDelete(t *testing.T) {
 	_, err := client.TrustedOrigins.DeleteTrustedOrigin("ow1y4s2cpS59f1xs2p7")
 	if err != nil {
 		t.Errorf("TrustedOrigins.DeleteTrustedOrigin returned error: %v", err)
+	}
+}
+
+func TestTrustedOriginActivate(t *testing.T) {
+	setup()
+	defer teardown()
+	setupTestTrustedOrigin()
+
+	testTrustedOrigin.ID = "ow1y4s2cpS59f1xs2p7"
+
+	mux.HandleFunc("/trustedOrigins/ow1y4s2cpS59f1xs2p7/lifecycle/activate", func(w http.ResponseWriter, r *http.Request) {
+		testMethod(t, r, "POST")
+		testAuthHeader(t, r)
+		fmt.Fprint(w, "")
+	})
+
+	_, err := client.TrustedOrigins.ActivateTrustedOrigin("ow1y4s2cpS59f1xs2p7", true)
+	if err != nil {
+		t.Errorf("TrustedOrigins.ActivateTrustedOrigin returned error: %v", err)
 	}
 }

--- a/okta/trusted_origins_test.go
+++ b/okta/trusted_origins_test.go
@@ -109,3 +109,23 @@ func TestTrustedOriginUpdate(t *testing.T) {
 		t.Errorf("client.TrustedOrigins.UpdateTrustedOrigin returned \n\t%+v, want \n\t%+v\n", outputTrustedOrigin.Name, testTrustedOrigin.Name)
 	}
 }
+
+func TestTrustedOriginDelete(t *testing.T) {
+
+	setup()
+	defer teardown()
+	setupTestTrustedOrigin()
+
+	testTrustedOrigin.ID = "ow1y4s2cpS59f1xs2p7"
+
+	mux.HandleFunc("/trustedOrigins/ow1y4s2cpS59f1xs2p7", func(w http.ResponseWriter, r *http.Request) {
+		testMethod(t, r, "DELETE")
+		testAuthHeader(t, r)
+		fmt.Fprint(w, "")
+	})
+
+	_, err := client.TrustedOrigins.DeleteTrustedOrigin("ow1y4s2cpS59f1xs2p7")
+	if err != nil {
+		t.Errorf("TrustedOrigins.DeleteTrustedOrigin returned error: %v", err)
+	}
+}


### PR DESCRIPTION
add the ability to do things for `Trusted Origins` in okta via the sdk

![](http://drops.articulate.com/X3qmf8/iPmrHakQoC+)