### PR TITLE
Use Pointers For Policy Ints

### DIFF
--- a/okta/policies.go
+++ b/okta/policies.go
@@ -77,14 +77,14 @@ type Enroll struct {
 // Password policy settings password obj
 type Password struct {
 	Complexity struct {
-		MinLength int `json:"minLength,omitempty"`
+		MinLength *int `json:"minLength,omitempty"`
 		// omitempty considers zero values on primitives empty. Thus if you have a value like one of these where the
 		// default is 1 but 0 is valid, you would never be able to set them to 0 because it would omit them and the
 		// API would default them. Same goes for other primitives.
-		MinLowerCase      int      `json:"minLowerCase"`
-		MinUpperCase      int      `json:"minUpperCase"`
-		MinNumber         int      `json:"minNumber"`
-		MinSymbol         int      `json:"minSymbol"`
+		MinLowerCase      *int     `json:"minLowerCase"`
+		MinUpperCase      *int     `json:"minUpperCase"`
+		MinNumber         *int     `json:"minNumber"`
+		MinSymbol         *int     `json:"minSymbol"`
 		ExcludeUsername   bool     `json:"excludeUsername"`
 		ExcludeAttributes []string `json:"excludeAttributes,omitempty"`
 		Dictionary        struct {
@@ -94,14 +94,14 @@ type Password struct {
 		} `json:"dictionary,omitempty"`
 	} `json:"complexity,omitempty"`
 	Age struct {
-		MaxAgeDays     int `json:"maxAgeDays,omitempty"`
-		ExpireWarnDays int `json:"expireWarnDays,omitempty"`
-		MinAgeMinutes  int `json:"minAgeMinutes,omitempty"`
-		HistoryCount   int `json:"historyCount,omitempty"`
+		MaxAgeDays     *int `json:"maxAgeDays,omitempty"`
+		ExpireWarnDays *int `json:"expireWarnDays,omitempty"`
+		MinAgeMinutes  *int `json:"minAgeMinutes,omitempty"`
+		HistoryCount   *int `json:"historyCount,omitempty"`
 	} `json:"age,omitempty"`
 	Lockout struct {
-		MaxAttempts         int  `json:"maxAttempts,omitempty"`
-		AutoUnlockMinutes   int  `json:"autoUnlockMinutes,omitempty"`
+		MaxAttempts         *int `json:"maxAttempts,omitempty"`
+		AutoUnlockMinutes   *int `json:"autoUnlockMinutes,omitempty"`
 		ShowLockoutFailures bool `json:"showLockoutFailures,omitempty"`
 	} `json:"lockout,omitempty"`
 }
@@ -113,7 +113,7 @@ type Recovery struct {
 			Status     string `json:"status,omitempty"`
 			Properties struct {
 				Complexity struct {
-					MinLength int `json:"minLength,omitempty"`
+					MinLength *int `json:"minLength,omitempty"`
 				} `json:"complexity,omitempty"`
 			} `json:"properties,omitempty"`
 		} `json:"recovery_question,omitempty"`

--- a/okta/policies_test.go
+++ b/okta/policies_test.go
@@ -54,8 +54,8 @@ func setupPassPolicy() {
 	testPassPolicyRecovery := &Recovery{}
 
 	testPassPolicyPassword := &Password{}
-	testPassPolicyPassword.Complexity.MinLength = 12
-	testPassPolicyPassword.Age.HistoryCount = 5
+	testPassPolicyPassword.Complexity.MinLength = intPtr(12)
+	testPassPolicyPassword.Age.HistoryCount = intPtr(5)
 
 	testPassPolicySettings := &PolicySettings{
 		Recovery: testPassPolicyRecovery,
@@ -101,8 +101,8 @@ func setupSignonPolicy() {
 	testSignonPolicyRecovery := &Recovery{}
 
 	testSignonPolicyPassword := &Password{}
-	testSignonPolicyPassword.Complexity.MinLength = 12
-	testSignonPolicyPassword.Age.HistoryCount = 5
+	testSignonPolicyPassword.Complexity.MinLength = intPtr(12)
+	testSignonPolicyPassword.Age.HistoryCount = intPtr(5)
 
 	testSignonPolicySettings := &PolicySettings{
 		Recovery: testSignonPolicyRecovery,
@@ -152,8 +152,8 @@ func setupInputPassPolicy() {
 	testInputPassPolicyRecovery := &Recovery{}
 
 	testInputPassPolicyPassword := &Password{}
-	testInputPassPolicyPassword.Complexity.MinLength = 12
-	testInputPassPolicyPassword.Age.HistoryCount = 5
+	testInputPassPolicyPassword.Complexity.MinLength = intPtr(12)
+	testInputPassPolicyPassword.Age.HistoryCount = intPtr(5)
 
 	testInputPassPolicySettings := &PolicySettings{
 		Recovery: testInputPassPolicyRecovery,
@@ -191,8 +191,8 @@ func setupInputSignonPolicy() {
 	testInputSignonPolicyRecovery := &Recovery{}
 
 	testInputSignonPolicyPassword := &Password{}
-	testInputSignonPolicyPassword.Complexity.MinLength = 12
-	testInputSignonPolicyPassword.Age.HistoryCount = 5
+	testInputSignonPolicyPassword.Complexity.MinLength = intPtr(12)
+	testInputSignonPolicyPassword.Age.HistoryCount = intPtr(5)
 
 	testInputSignonPolicySettings := &PolicySettings{
 		Recovery: testInputSignonPolicyRecovery,

--- a/okta/utils.go
+++ b/okta/utils.go
@@ -1,0 +1,5 @@
+package okta
+
+func intPtr(i int) *int {
+	return &i
+}


### PR DESCRIPTION
Many of these values can be set to 0, thus by using pointers we avoid omitting values when they are 0. They will instead be omitted when `nil`.