### PR TITLE
Extending the policies structure to add userLockoutNotificationChannels

### DIFF
--- a/okta/policies.go
+++ b/okta/policies.go
@@ -100,10 +100,10 @@ type Password struct {
 		HistoryCount   *int `json:"historyCount,omitempty"`
 	} `json:"age,omitempty"`
 	Lockout struct {
-		MaxAttempts         *int `json:"maxAttempts,omitempty"`
-		AutoUnlockMinutes   *int `json:"autoUnlockMinutes,omitempty"`
-		ShowLockoutFailures bool `json:"showLockoutFailures,omitempty"`
-                UserLockoutNotificationChannels []string `json:"UserLockoutNotificationChannels,omitempty"`
+		MaxAttempts                     *int     `json:"maxAttempts,omitempty"`
+		AutoUnlockMinutes               *int     `json:"autoUnlockMinutes,omitempty"`
+		ShowLockoutFailures             bool     `json:"showLockoutFailures,omitempty"`
+		UserLockoutNotificationChannels []string `json:"UserLockoutNotificationChannels,omitempty"`
 	} `json:"lockout,omitempty"`
 }
 

--- a/okta/policies.go
+++ b/okta/policies.go
@@ -103,6 +103,7 @@ type Password struct {
 		MaxAttempts         *int `json:"maxAttempts,omitempty"`
 		AutoUnlockMinutes   *int `json:"autoUnlockMinutes,omitempty"`
 		ShowLockoutFailures bool `json:"showLockoutFailures,omitempty"`
+                UserLockoutNotificationChannels []string `json:"UserLockoutNotificationChannels,omitempty"`
 	} `json:"lockout,omitempty"`
 }
 


### PR DESCRIPTION
To add the notification channel for user lockout in the policy (currently E-mail seems to be the only value) needed to extend the policies struct.

More at: https://github.com/articulate/terraform-provider-okta/issues/328