### PR TITLE
Fix case of userlockoutnotificationchannels

### DIFF
--- a/okta/policies.go
+++ b/okta/policies.go
@@ -103,7 +103,7 @@ type Password struct {
 		MaxAttempts                     *int     `json:"maxAttempts,omitempty"`
 		AutoUnlockMinutes               *int     `json:"autoUnlockMinutes,omitempty"`
 		ShowLockoutFailures             bool     `json:"showLockoutFailures,omitempty"`
-		UserLockoutNotificationChannels []string `json:"UserLockoutNotificationChannels,omitempty"`
+		UserLockoutNotificationChannels []string `json:"userLockoutNotificationChannels,omitempty"`
 	} `json:"lockout,omitempty"`
 }
 


### PR DESCRIPTION
There is a typo in the json definition of `userlockoutnotificationchannels` where the first letter is capitalized.

Unfortunately, this results in an error when trying to create/update a policy through the SDK:

```shell
HTTP Status Code: 400, OKTA Error Code: E0000001, OKTA Error Summary: Api validation failed: The policy could not be created or updated because the request was not formatted correctly. Please ensure that the value of the "type" field is valid and that the rest of the body conforms to the expected format for that type., OKTA Error Causes: [{The policy could not be created or updated because the request was not formatted correctly. Please ensure that the value of the "type" field is valid and that the rest of the body conforms to the expecte
d format for that type.}]
```

This PR addresses that.